### PR TITLE
Set all regexes to be case-insensitive by default.

### DIFF
--- a/bin/harvestgoogle.js
+++ b/bin/harvestgoogle.js
@@ -659,7 +659,7 @@ Harvester = (function() {
           var property, regex;
           for (property in rule) {
             regex = rule[property];
-            if (new RegExp(regex).test(event[property])) {
+            if (new RegExp(regex, "i").test(event[property])) {
               event.matched_by = mapping;
               return true;
             } else {

--- a/lib/harvestgoogle.coffee
+++ b/lib/harvestgoogle.coffee
@@ -501,7 +501,7 @@ class Harvester
               mapping.rules,
               (rule) ->
                 for property, regex of rule
-                  if new RegExp(regex).test(event[property])
+                  if new RegExp(regex, "i").test(event[property])
                     event.matched_by = mapping
                     return true
                   else


### PR DESCRIPTION
It seems like an unlikely use case that anyone would want to differentiate mappings by capitalization. This removes the need for match patterns like `[Ss]print`, allowing `sprint` to match `Sprint`, `sprint` or even `SPRINT`.
