### PR TITLE
Change Google timeMax timestamp to T23:59:59.999Z

### DIFF
--- a/bin/harvestgoogle.js
+++ b/bin/harvestgoogle.js
@@ -66,7 +66,7 @@ GoogleCalendar = (function() {
     if (this.authenticated) {
       query.from = "" + query.from.slice(0, 4) + "-" + query.from.slice(4, 6) + "-" + query.from.slice(6, 8);
       query.to = "" + query.to.slice(0, 4) + "-" + query.to.slice(4, 6) + "-" + query.to.slice(6, 8);
-      path = "/calendar/v3/calendars/" + (encodeURIComponent(query.calendar)) + "/events?key=AIzaSyB-wuGViS_V9ZZpF_GQVQxrxtnw2E3iL3c&timeMin=" + (encodeURIComponent(query.from + "T00:00:00.000Z")) + "&timeMax=" + (encodeURIComponent(query.to + "T00:00:00.000Z")) + "&maxResults=" + this.maxResults;
+      path = "/calendar/v3/calendars/" + (encodeURIComponent(query.calendar)) + "/events?key=AIzaSyB-wuGViS_V9ZZpF_GQVQxrxtnw2E3iL3c&timeMin=" + (encodeURIComponent(query.from + "T00:00:00.000Z")) + "&timeMax=" + (encodeURIComponent(query.to + "T23:59:59.999Z")) + "&maxResults=" + this.maxResults;
       options = {
         host: 'www.googleapis.com',
         path: path,

--- a/lib/harvestgoogle.coffee
+++ b/lib/harvestgoogle.coffee
@@ -58,7 +58,7 @@ class GoogleCalendar
     if @authenticated
       query.from = "#{query.from[0..3]}-#{query.from[4..5]}-#{query.from[6..7]}"
       query.to = "#{query.to[0..3]}-#{query.to[4..5]}-#{query.to[6..7]}"
-      path = "/calendar/v3/calendars/#{encodeURIComponent(query.calendar)}/events?key=AIzaSyB-wuGViS_V9ZZpF_GQVQxrxtnw2E3iL3c&timeMin=#{encodeURIComponent(query.from+"T00:00:00.000Z")}&timeMax=#{encodeURIComponent(query.to+"T00:00:00.000Z")}&maxResults=#{@maxResults}"
+      path = "/calendar/v3/calendars/#{encodeURIComponent(query.calendar)}/events?key=AIzaSyB-wuGViS_V9ZZpF_GQVQxrxtnw2E3iL3c&timeMin=#{encodeURIComponent(query.from+"T00:00:00.000Z")}&timeMax=#{encodeURIComponent(query.to+"T23:59:59.999Z")}&maxResults=#{@maxResults}"
       options = 
         host: 'www.googleapis.com'
         path: path


### PR DESCRIPTION
It appears that the Harvest range query is inclusive of the final date, while the Google query is exclusive.

That is, for a given range `20140410..20140410`, Harvest returns all time entries for the day `April 10th`, while Google returns no entries.

This appears to be because the timestamp appended to timeMax is currently `T00:00:00.000Z` (the start of the day). Changing it to `T23:59:59.999Z` makes the Google and Harvest queries consistent: a range of one day will return events for that one day, and a range of multiple days will include events on the last day.
