### PR TITLE
Expand recurring event instances to real events.

### DIFF
--- a/bin/harvestgoogle.js
+++ b/bin/harvestgoogle.js
@@ -66,7 +66,7 @@ GoogleCalendar = (function() {
     if (this.authenticated) {
       query.from = "" + query.from.slice(0, 4) + "-" + query.from.slice(4, 6) + "-" + query.from.slice(6, 8);
       query.to = "" + query.to.slice(0, 4) + "-" + query.to.slice(4, 6) + "-" + query.to.slice(6, 8);
-      path = "/calendar/v3/calendars/" + (encodeURIComponent(query.calendar)) + "/events?key=AIzaSyB-wuGViS_V9ZZpF_GQVQxrxtnw2E3iL3c&timeMin=" + (encodeURIComponent(query.from + "T00:00:00.000Z")) + "&timeMax=" + (encodeURIComponent(query.to + "T00:00:00.000Z")) + "&maxResults=" + this.maxResults;
+      path = "/calendar/v3/calendars/" + (encodeURIComponent(query.calendar)) + "/events?key=AIzaSyB-wuGViS_V9ZZpF_GQVQxrxtnw2E3iL3c&singleEvents=true&timeMin=" + (encodeURIComponent(query.from + "T00:00:00.000Z")) + "&timeMax=" + (encodeURIComponent(query.to + "T00:00:00.000Z")) + "&maxResults=" + this.maxResults;
       options = {
         host: 'www.googleapis.com',
         path: path,
@@ -94,9 +94,6 @@ GoogleCalendar = (function() {
             event = events[_i];
             _fn(event);
           }
-          events = _.filter(events, function(event) {
-            return event.recurrence == null;
-          });
           return data(events);
         });
       });

--- a/lib/harvestgoogle.coffee
+++ b/lib/harvestgoogle.coffee
@@ -58,7 +58,7 @@ class GoogleCalendar
     if @authenticated
       query.from = "#{query.from[0..3]}-#{query.from[4..5]}-#{query.from[6..7]}"
       query.to = "#{query.to[0..3]}-#{query.to[4..5]}-#{query.to[6..7]}"
-      path = "/calendar/v3/calendars/#{encodeURIComponent(query.calendar)}/events?key=AIzaSyB-wuGViS_V9ZZpF_GQVQxrxtnw2E3iL3c&timeMin=#{encodeURIComponent(query.from+"T00:00:00.000Z")}&timeMax=#{encodeURIComponent(query.to+"T00:00:00.000Z")}&maxResults=#{@maxResults}"
+      path = "/calendar/v3/calendars/#{encodeURIComponent(query.calendar)}/events?key=AIzaSyB-wuGViS_V9ZZpF_GQVQxrxtnw2E3iL3c&singleEvents=true&timeMin=#{encodeURIComponent(query.from+"T00:00:00.000Z")}&timeMax=#{encodeURIComponent(query.to+"T00:00:00.000Z")}&maxResults=#{@maxResults}"
       options = 
         host: 'www.googleapis.com'
         path: path
@@ -81,8 +81,6 @@ class GoogleCalendar
                 do (event) ->
                   if event.start?.dateTime? and event.end?.dateTime?
                     event.duration_in_hours = parseFloat(moment(event.end.dateTime).diff(moment(event.start.dateTime),"hours",true)).toFixed(2)
-              # we do not want the original recurrence
-              events = _.filter(events, (event) -> not event.recurrence?)
               data(events)
           )
       )


### PR DESCRIPTION
See [Calendar API v3 Best Practices: Recurring Events](http://googleappsdeveloper.blogspot.com/2011/12/calendar-v3-best-practices-recurring.html)

> By default, when listing events on a calendar, recurring events and all exceptions (including canceled events) are returned. To avoid having to expand recurring events, a client can set the singleEvents query parameter to true, like in the previous versions of the API. Doing so excludes the recurring events, but includes all expanded instances.

The current script worked around recurring events by ignoring them
completely. That is, the Calendar API would return the first event
date, but not any of the recurrances.

This changes the API query to request recurring events as single events.
This causes recurring events to show as their "real" dates and times,
and has the additional benefit of also ignoring individual instances
that have been deleted from the calendar.
